### PR TITLE
build(ci): separate worflows for PRs and master

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,7 @@
+name: Test branch
+on:
+  push:
+    branches: [ $default-branch ]
+jobs:
+  Call-Test-Branch:
+    uses: ./.github/workflows/test-branch.yml

--- a/.github/workflows/test-branch.yml
+++ b/.github/workflows/test-branch.yml
@@ -1,5 +1,5 @@
 name: Test branch
-on: [push]
+on: workflow_call
 jobs:
   Test-Branch:
     runs-on: ubuntu-latest

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -1,0 +1,5 @@
+name: Test branch
+on: pull_request
+jobs:
+  Call-Test-Branch:
+    uses: ./.github/workflows/test-branch.yml


### PR DESCRIPTION
## Build
### CI: separate worflows for PRs and master
The `test-branch` workflow has been refactored as a reusable workflow. It is reused in `validate-pr` (that will launch test for a PR) and `deploy` (that will launch test for `master`). 

For this first iteration, `validate-pr` and `deploy` do the same thing. The purpose is to add a deployment job to `deploy` in a later time. 