### PR TITLE
Deploy on gh-pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,7 +1,18 @@
-name: Test branch
+name: Deploy
 on:
   push:
     branches: [ master ]
 jobs:
-  Call-Test-Branch:
-    uses: ./.github/workflows/test-branch.yml
+  test-and-deploy:
+    concurrency:
+      group: production
+      cancel-in-progress: true
+    steps:
+    - name: Launch tests
+      uses: ./.github/workflows/test-branch.yml
+    - run: yarn build
+    - name: Deploy to Github Pages
+      uses: peaceiris/actions-gh-pages@v3
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: ./dist

--- a/.github/workflows/test-branch.yml
+++ b/.github/workflows/test-branch.yml
@@ -1,7 +1,7 @@
 name: Test branch
 on: workflow_call
 jobs:
-  Test-Branch:
+  test-branch:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -1,5 +1,5 @@
-name: Test branch
+name: Validate PR
 on: pull_request
 jobs:
-  Call-Test-Branch:
+  call-test-branch:
     uses: ./.github/workflows/test-branch.yml

--- a/package.json
+++ b/package.json
@@ -11,14 +11,14 @@
     "test": "tests"
   },
   "scripts": {
-    "build": "ember build --environment=production --output-path=marine",
-    "deploy": "find marine/ -type f -exec curl --ftp-create-dirs -T {} ftp://${FTP_USER}:${FTP_PASSWORD}@greatwizard.fr/{} --ftp-ssl -k \\;",
+    "build": "ember build --environment=production",
     "lint": "npm-run-all --aggregate-output --continue-on-error --parallel 'lint:!(fix)'",
     "lint:fix": "npm-run-all --aggregate-output --continue-on-error --parallel lint:*:fix",
     "lint:hbs": "ember-template-lint .",
     "lint:hbs:fix": "ember-template-lint . --fix",
     "lint:js": "eslint . --cache",
     "lint:js:fix": "eslint . --fix",
+    "postbuild": "echo 'marine.dunstetter.fr' > dist/CNAME",
     "start": "ember serve",
     "test": "npm-run-all lint test:*",
     "test:ember": "ember test"


### PR DESCRIPTION
## Build
### CI: deploy app to Github pages
The `deploy` workflow has been modified to deploy the application to Github pages on merge on `master`:
- The build command has been cleaned up in `package.json`.
- The public action from [peaceiris/actions-gh-pages](https://github.com/peaceiris/actions-gh-pages) has been used to perform the deployment of the build.
- The `CNAME` file has been removed and replaced with a `postbuild` instruction that creates it in the `/dist` folder after building (Note: postbuild command is automatically call by `yarn build` and doesn't need to be added to the workflows' steps). 