### PR TITLE
Route inheritance

### DIFF
--- a/app/routes/home/apps.js
+++ b/app/routes/home/apps.js
@@ -1,16 +1,6 @@
-import Route from '@ember/routing/route';
-import config from 'site-cv/config/environment';
+import CategoryRoute from 'site-cv/routing/category-route';
 
-export default class AppsRoute extends Route {
-  model() {
-    return this.store.peekAll('category').filter(function (category) {
-      return category.get('keyroute') === 'apps';
-    });
-  }
-
-  afterModel(_, transition) {
-    if (transition.targetName.includes('apps.index')) {
-      this.transitionTo('home.apps.app', config.APP.defaultProjectId.apps);
-    }
-  }
+export default class AppsRoute extends CategoryRoute {
+  keyRoute = 'apps';
+  transitionRoute = 'home.apps.app';
 }

--- a/app/routes/home/apps/app.js
+++ b/app/routes/home/apps/app.js
@@ -1,17 +1,3 @@
-import Route from '@ember/routing/route';
-import { getOwner } from '@ember/application';
+import ProjectRoute from 'site-cv/routing/project-route';
 
-export default class AppsAppRoute extends Route {
-  model(params) {
-    this.templateName = params.id;
-    return this.store.peekRecord('project', params.id);
-  }
-
-  renderTemplate() {
-    let panelName = `panels.${this.templateName}`;
-    if (getOwner(this).lookup(`template:${panelName}`) === undefined) {
-      panelName = 'panels.default';
-    }
-    this.render(panelName);
-  }
-}
+export default class AppsAppRoute extends ProjectRoute {}

--- a/app/routes/home/art.js
+++ b/app/routes/home/art.js
@@ -1,16 +1,6 @@
-import Route from '@ember/routing/route';
-import config from 'site-cv/config/environment';
+import CategoryRoute from 'site-cv/routing/category-route';
 
-export default class ArtRoute extends Route {
-  model() {
-    return this.store.peekAll('category').filter(function (category) {
-      return category.get('keyroute') === 'art';
-    });
-  }
-
-  afterModel(_, transition) {
-    if (transition.targetName.includes('art.index')) {
-      this.transitionTo('home.art.collection', config.APP.defaultProjectId.art);
-    }
-  }
+export default class ArtRoute extends CategoryRoute {
+  keyRoute = 'art';
+  transitionRoute = 'home.art.collection';
 }

--- a/app/routes/home/art/collection.js
+++ b/app/routes/home/art/collection.js
@@ -1,17 +1,3 @@
-import Route from '@ember/routing/route';
-import { getOwner } from '@ember/application';
+import ProjectRoute from 'site-cv/routing/project-route';
 
-export default class ArtCollectionRoute extends Route {
-  model(params) {
-    this.templateName = params.id;
-    return this.store.peekRecord('project', params.id);
-  }
-
-  renderTemplate() {
-    let panelName = `panels.${this.templateName}`;
-    if (getOwner(this).lookup(`template:${panelName}`) === undefined) {
-      panelName = 'panels.default';
-    }
-    this.render(panelName);
-  }
-}
+export default class ArtCollectionRoute extends ProjectRoute {}

--- a/app/routes/home/games.js
+++ b/app/routes/home/games.js
@@ -1,16 +1,6 @@
-import Route from '@ember/routing/route';
-import config from 'site-cv/config/environment';
+import CategoryRoute from 'site-cv/routing/category-route';
 
-export default class GamesRoute extends Route {
-  model() {
-    return this.store.peekAll('category').filter(function (category) {
-      return category.get('keyroute') === 'games';
-    });
-  }
-
-  afterModel(_, transition) {
-    if (transition.targetName.includes('games.index')) {
-      this.transitionTo('home.games.game', config.APP.defaultProjectId.games);
-    }
-  }
+export default class GamesRoute extends CategoryRoute {
+  keyRoute = 'games';
+  transitionRoute = 'home.games.game';
 }

--- a/app/routes/home/games/game.js
+++ b/app/routes/home/games/game.js
@@ -1,17 +1,3 @@
-import Route from '@ember/routing/route';
-import { getOwner } from '@ember/application';
+import ProjectRoute from 'site-cv/routing/project-route';
 
-export default class GamesGameRoute extends Route {
-  model(params) {
-    this.templateName = params.id;
-    return this.store.peekRecord('project', params.id);
-  }
-
-  renderTemplate() {
-    let panelName = `panels.${this.templateName}`;
-    if (getOwner(this).lookup(`template:${panelName}`) === undefined) {
-      panelName = 'panels.default';
-    }
-    this.render(panelName);
-  }
-}
+export default class GamesGameRoute extends ProjectRoute {}

--- a/app/routing/category-route.js
+++ b/app/routing/category-route.js
@@ -1,0 +1,22 @@
+import Route from '@ember/routing/route';
+import config from 'site-cv/config/environment';
+
+export default class CategoryRoute extends Route {
+  keyRoute = '';
+  transitionRoute = '';
+
+  model() {
+    return this.store.peekAll('category').filter((category) => {
+      return category.get('keyroute') === this.keyRoute;
+    });
+  }
+
+  afterModel(_, transition) {
+    if (transition.targetName.includes(`${this.keyRoute}.index`)) {
+      this.transitionTo(
+        this.transitionRoute,
+        config.APP.defaultProjectId[this.keyRoute]
+      );
+    }
+  }
+}

--- a/app/routing/project-route.js
+++ b/app/routing/project-route.js
@@ -1,0 +1,17 @@
+import Route from '@ember/routing/route';
+import { getOwner } from '@ember/application';
+
+export default class ProjectRoute extends Route {
+  model(params) {
+    this.templateName = params.id;
+    return this.store.peekRecord('project', params.id);
+  }
+
+  renderTemplate() {
+    let panelName = `panels.${this.templateName}`;
+    if (getOwner(this).lookup(`template:${panelName}`) === undefined) {
+      panelName = 'panels.default';
+    }
+    this.render(panelName);
+  }
+}

--- a/app/templates/panels/travel.hbs
+++ b/app/templates/panels/travel.hbs
@@ -3,7 +3,7 @@
   <p>{{t "category.slot.travel.intro"}}</p>
   <div class="project-part t1">
     <p>{{t "category.slot.travel.japanIntro"}}</p>
-    <a href="https://panodyssey.com/fr/creative/room/l17-la-salle-de-langue-e65ncc9kc74q"
+    <a href="https://panodyssey.com/fr/creative/room/les-carnets-du-japon-e65ncc9kc74q"
       target="_blank"
       rel="noopener noreferrer"
     >

--- a/public/api/projects.json
+++ b/public/api/projects.json
@@ -26,6 +26,16 @@
       "name":"Homeplay"
     },
     {
+      "id":"formidable",
+      "type":"project-panel",
+      "name":"Formidable"
+    },
+    {
+      "id":"mypeopledoc",
+      "type":"project-panel",
+      "name":"MyPeopleDoc"
+    },
+    {
       "id":"eds",
       "type":"project-panel",
       "name":"AXA Esprit de service"


### PR DESCRIPTION
## Refactor
### Routes inheritance
The different main routes and sub routes of the application work the same way. The code has been factorize in generic parent classes. 

## Fixes
### `travel` panel external link
When I renamed the creative room on Panodyssey, Panodyssey changed the URL accordingly, making the link in `travel` panel obsolete. 

### Missing fixtures for `formidable` and `mypeopledoc`
Projects fixtures have become not so relevant with the way the application evolved, but they are still here and used to make the routing work correctly. `formidable` and `mypeopledoc` were missing in the api folder. As result, `renderTemplate` was not called after the model hook when one of these two was selected in the menu.