### PR TITLE
Refactor/ Factorize project header

### DIFF
--- a/app/components/project-template.hbs
+++ b/app/components/project-template.hbs
@@ -1,5 +1,7 @@
 <div class="project-template borderleft">
-  <h1>{{t (concat "category.slot." @projectId ".label")}}</h1>
-  <p>{{t (concat "category.slot." @projectId ".intro")}}</p>
-  {{yield}}
+  {{#let (concat "category.slot." @projectId ".") as |tkey|}}
+    <h1>{{t (concat tkey "label")}}</h1>
+    <p>{{t (concat tkey "intro")}}</p>
+    {{yield tkey}}
+  {{/let}}
 </div>

--- a/app/components/project-template.hbs
+++ b/app/components/project-template.hbs
@@ -1,0 +1,5 @@
+<div class="project-template borderleft">
+  <h1>{{t (concat "category.slot." @projectId ".label")}}</h1>
+  <p>{{t (concat "category.slot." @projectId ".intro")}}</p>
+  {{yield}}
+</div>

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -465,7 +465,7 @@ a.active .menu-bar-item  {
       text-align: justify;
     }
 
-    &.t1 {
+    &:nth-child(odd) {
       background-color: $item-color2;
     }
 

--- a/app/templates/panels/bewilderhouse.hbs
+++ b/app/templates/panels/bewilderhouse.hbs
@@ -1,7 +1,4 @@
-<div class="project-template borderleft">
-  <h1>{{t "category.slot.bewilderhouse.label"}}</h1>
-  <p>{{t "category.slot.bewilderhouse.intro"}}</p>
-
+<ProjectTemplate @projectId="bewilderhouse">
   <div class="project-part t2">
     <h2>{{t "general.trailer"}}</h2>
     <div class="video">
@@ -64,5 +61,4 @@
     <p>{{t "category.slot.bewilderhouse.minoteam" htmlSafe=true}}</p>
     <p>{{t "category.slot.bewilderhouse.minotaure"}}</p>
   </div>
-
-</div>
+</ProjectTemplate>

--- a/app/templates/panels/bewilderhouse.hbs
+++ b/app/templates/panels/bewilderhouse.hbs
@@ -1,5 +1,5 @@
 <ProjectTemplate @projectId="bewilderhouse">
-  <div class="project-part t2">
+  <div class="project-part">
     <h2>{{t "general.trailer"}}</h2>
     <div class="video">
       <iframe
@@ -13,7 +13,7 @@
     </div>
   </div>
 
-  <div class="project-part t1">
+  <div class="project-part">
     <p>{{t "category.slot.bewilderhouse.linkGamejolt"
         htmlSafe=true
         gamejolt="http://gamejolt.com/games/puzzle/bewilder-house/17297"
@@ -25,12 +25,12 @@
     <p>{{t "category.slot.bewilderhouse.linkMail" htmlSafe=true}}</p>
   </div>
 
-  <div class="project-part t2">
+  <div class="project-part">
     <h2>{{t "general.about"}}</h2>
     <p>{{t "category.slot.bewilderhouse.about"}}</p>
   </div>
 
-  <div class="project-part t1">
+  <div class="project-part">
     <div class="video">
       <video controls
         src="/video/bewilder_trailer_univers.mp4"
@@ -41,7 +41,7 @@
     <p>{{t "category.slot.bewilderhouse.trailerUniverse"}}</p>
   </div>
 
-  <div class="project-part t2">
+  <div class="project-part">
     <h2>{{t "general.gd"}}</h2>
     <p>{{t "category.slot.bewilderhouse.gd1"}}</p>
     <p>{{t "category.slot.bewilderhouse.gd2"}}</p>
@@ -49,14 +49,14 @@
     <p>{{t "category.slot.bewilderhouse.gd4"}}</p>
   </div>
 
-  <div class="project-part t1">
+  <div class="project-part">
     <h2>{{t "general.universe"}}</h2>
     <p>{{t "category.slot.bewilderhouse.universeIntro"}}</p>
     <ul>{{t "category.slot.bewilderhouse.universeContent" htmlSafe=true}}</ul>
     <p>{{t "category.slot.bewilderhouse.universeConclusion"}}</p>
   </div>
 
-  <div class="project-part t2">
+  <div class="project-part">
     <h2>{{t "general.anecdote"}}</h2>
     <p>{{t "category.slot.bewilderhouse.minoteam" htmlSafe=true}}</p>
     <p>{{t "category.slot.bewilderhouse.minotaure"}}</p>

--- a/app/templates/panels/bewilderhouse.hbs
+++ b/app/templates/panels/bewilderhouse.hbs
@@ -1,9 +1,9 @@
-<ProjectTemplate @projectId="bewilderhouse">
+<ProjectTemplate @projectId="bewilderhouse" as |tkey|>
   <div class="project-part">
     <h2>{{t "general.trailer"}}</h2>
     <div class="video">
       <iframe
-        title={{t "category.slot.bewilderhouse.trailer"}}
+        title={{t (concat tkey "trailer")}}
         width="640"
         height="360"
         src="https://www.youtube.com/embed/H49-RM41b4I"
@@ -14,20 +14,20 @@
   </div>
 
   <div class="project-part">
-    <p>{{t "category.slot.bewilderhouse.linkGamejolt"
+    <p>{{t (concat tkey "linkGamejolt")
         htmlSafe=true
         gamejolt="http://gamejolt.com/games/puzzle/bewilder-house/17297"
       }}</p>
-    <p>{{t "category.slot.bewilderhouse.linkFacebook"
+    <p>{{t (concat tkey "linkFacebook")
         htmlSafe=true
         facebook="https://www.facebook.com/Bewilder-House-official-255616847933869"
       }}</p>
-    <p>{{t "category.slot.bewilderhouse.linkMail" htmlSafe=true}}</p>
+    <p>{{t (concat tkey "linkMail") htmlSafe=true}}</p>
   </div>
 
   <div class="project-part">
     <h2>{{t "general.about"}}</h2>
-    <p>{{t "category.slot.bewilderhouse.about"}}</p>
+    <p>{{t (concat tkey "about")}}</p>
   </div>
 
   <div class="project-part">
@@ -38,27 +38,27 @@
         height="360">
       </video>
     </div>
-    <p>{{t "category.slot.bewilderhouse.trailerUniverse"}}</p>
+    <p>{{t (concat tkey "trailerUniverse")}}</p>
   </div>
 
   <div class="project-part">
     <h2>{{t "general.gd"}}</h2>
-    <p>{{t "category.slot.bewilderhouse.gd1"}}</p>
-    <p>{{t "category.slot.bewilderhouse.gd2"}}</p>
-    <p>{{t "category.slot.bewilderhouse.gd3"}}</p>
-    <p>{{t "category.slot.bewilderhouse.gd4"}}</p>
+    <p>{{t (concat tkey "gd1")}}</p>
+    <p>{{t (concat tkey "gd2")}}</p>
+    <p>{{t (concat tkey "gd3")}}</p>
+    <p>{{t (concat tkey "gd4")}}</p>
   </div>
 
   <div class="project-part">
     <h2>{{t "general.universe"}}</h2>
-    <p>{{t "category.slot.bewilderhouse.universeIntro"}}</p>
-    <ul>{{t "category.slot.bewilderhouse.universeContent" htmlSafe=true}}</ul>
-    <p>{{t "category.slot.bewilderhouse.universeConclusion"}}</p>
+    <p>{{t (concat tkey "universeIntro")}}</p>
+    <ul>{{t (concat tkey "universeContent") htmlSafe=true}}</ul>
+    <p>{{t (concat tkey "universeConclusion")}}</p>
   </div>
 
   <div class="project-part">
     <h2>{{t "general.anecdote"}}</h2>
-    <p>{{t "category.slot.bewilderhouse.minoteam" htmlSafe=true}}</p>
-    <p>{{t "category.slot.bewilderhouse.minotaure"}}</p>
+    <p>{{t (concat tkey "minoteam") htmlSafe=true}}</p>
+    <p>{{t (concat tkey "minotaure")}}</p>
   </div>
 </ProjectTemplate>

--- a/app/templates/panels/dysd.hbs
+++ b/app/templates/panels/dysd.hbs
@@ -1,7 +1,4 @@
-<div class="project-template borderleft">
-  <h1>{{t "category.slot.dysd.label"}}</h1>
-  <p>{{t "category.slot.dysd.intro"}}</p>
-
+<ProjectTemplate @projectId="dysd">
   <div class="project-part t1">
     <p>{{t "category.slot.dysd.about"}}</p>
   </div>
@@ -9,5 +6,4 @@
   <div class="project-part t2">
     <p>{{t "category.slot.dysd.tech"}}</p>
   </div>
-
-</div>
+</ProjectTemplate>

--- a/app/templates/panels/dysd.hbs
+++ b/app/templates/panels/dysd.hbs
@@ -1,9 +1,9 @@
-<ProjectTemplate @projectId="dysd">
+<ProjectTemplate @projectId="dysd" as |tkey|>
   <div class="project-part">
-    <p>{{t "category.slot.dysd.about"}}</p>
+    <p>{{t (concat tkey "about")}}</p>
   </div>
 
   <div class="project-part">
-    <p>{{t "category.slot.dysd.tech"}}</p>
+    <p>{{t (concat tkey "tech")}}</p>
   </div>
 </ProjectTemplate>

--- a/app/templates/panels/dysd.hbs
+++ b/app/templates/panels/dysd.hbs
@@ -1,9 +1,9 @@
 <ProjectTemplate @projectId="dysd">
-  <div class="project-part t1">
+  <div class="project-part">
     <p>{{t "category.slot.dysd.about"}}</p>
   </div>
 
-  <div class="project-part t2">
+  <div class="project-part">
     <p>{{t "category.slot.dysd.tech"}}</p>
   </div>
 </ProjectTemplate>

--- a/app/templates/panels/ecosmart.hbs
+++ b/app/templates/panels/ecosmart.hbs
@@ -1,6 +1,4 @@
-<div class="project-template borderleft">
-  <h1>{{t "category.slot.ecosmart.label"}}</h1>
-  <p>{{t "category.slot.ecosmart.intro"}}</p>
+<ProjectTemplate @projectId="ecosmart">
   <div class="project-part t1">
     <p>{{t "category.slot.ecosmart.about"}}</p>
   </div>
@@ -12,4 +10,4 @@
     <h2>{{t "category.slot.ecosmart.title2"}}</h2>
     <p>{{t "category.slot.ecosmart.content2" htmlSafe=true}}</p>
   </div>
-</div>
+</ProjectTemplate>

--- a/app/templates/panels/ecosmart.hbs
+++ b/app/templates/panels/ecosmart.hbs
@@ -1,12 +1,12 @@
 <ProjectTemplate @projectId="ecosmart">
-  <div class="project-part t1">
+  <div class="project-part">
     <p>{{t "category.slot.ecosmart.about"}}</p>
   </div>
-  <div class="project-part t2">
+  <div class="project-part">
     <h2>{{t "category.slot.ecosmart.title1"}}</h2>
     <p>{{t "category.slot.ecosmart.content1" htmlSafe=true}}</p>
   </div>
-  <div class="project-part t1">
+  <div class="project-part">
     <h2>{{t "category.slot.ecosmart.title2"}}</h2>
     <p>{{t "category.slot.ecosmart.content2" htmlSafe=true}}</p>
   </div>

--- a/app/templates/panels/ecosmart.hbs
+++ b/app/templates/panels/ecosmart.hbs
@@ -1,13 +1,13 @@
-<ProjectTemplate @projectId="ecosmart">
+<ProjectTemplate @projectId="ecosmart" as |tkey|>
   <div class="project-part">
-    <p>{{t "category.slot.ecosmart.about"}}</p>
+    <p>{{t (concat tkey "about")}}</p>
   </div>
   <div class="project-part">
-    <h2>{{t "category.slot.ecosmart.title1"}}</h2>
-    <p>{{t "category.slot.ecosmart.content1" htmlSafe=true}}</p>
+    <h2>{{t (concat tkey "title1")}}</h2>
+    <p>{{t (concat tkey "content1") htmlSafe=true}}</p>
   </div>
   <div class="project-part">
-    <h2>{{t "category.slot.ecosmart.title2"}}</h2>
-    <p>{{t "category.slot.ecosmart.content2" htmlSafe=true}}</p>
+    <h2>{{t (concat tkey "title2")}}</h2>
+    <p>{{t (concat tkey "content2") htmlSafe=true}}</p>
   </div>
 </ProjectTemplate>

--- a/app/templates/panels/eds.hbs
+++ b/app/templates/panels/eds.hbs
@@ -1,8 +1,5 @@
-<div class="project-template borderleft">
-  <h1>{{t "category.slot.eds.label"}}</h1>
-  <p>{{t "category.slot.eds.intro"}}</p>
-
+<ProjectTemplate @projectId="eds">
   <div class="project-part t1">
     <p>{{t "category.slot.eds.about"}}</p>
   </div>
-</div>
+</ProjectTemplate>

--- a/app/templates/panels/eds.hbs
+++ b/app/templates/panels/eds.hbs
@@ -1,5 +1,5 @@
-<ProjectTemplate @projectId="eds">
+<ProjectTemplate @projectId="eds" as |tkey|>
   <div class="project-part">
-    <p>{{t "category.slot.eds.about"}}</p>
+    <p>{{t (concat tkey "about")}}</p>
   </div>
 </ProjectTemplate>

--- a/app/templates/panels/eds.hbs
+++ b/app/templates/panels/eds.hbs
@@ -1,5 +1,5 @@
 <ProjectTemplate @projectId="eds">
-  <div class="project-part t1">
+  <div class="project-part">
     <p>{{t "category.slot.eds.about"}}</p>
   </div>
 </ProjectTemplate>

--- a/app/templates/panels/energycat.hbs
+++ b/app/templates/panels/energycat.hbs
@@ -1,15 +1,15 @@
-<ProjectTemplate @projectId="energycat">
+<ProjectTemplate @projectId="energycat" as |tkey|>
   <img
-    alt={{t "category.slot.energycat.image"}}
+    alt={{t (concat tkey "image")}}
     src="/img/banners/banner-energycat-start.png"
   />
 
   <div class="project-part">
-    <p>{{t "category.slot.energycat.about"}}</p>
+    <p>{{t (concat tkey "about")}}</p>
   </div>
 
   <div class="project-part">
-    <p>{{t "category.slot.energycat.link"
+    <p>{{t (concat tkey "link")
       energaware="https://www.energaware.eu/#"
       htmlSafe=true
     }}</p>

--- a/app/templates/panels/energycat.hbs
+++ b/app/templates/panels/energycat.hbs
@@ -1,7 +1,4 @@
-<div class="project-template borderleft">
-  <h1>{{t "category.slot.energycat.label"}}</h1>
-  <p>{{t "category.slot.energycat.intro"}}</p>
-
+<ProjectTemplate @projectId="energycat">
   <img
     alt={{t "category.slot.energycat.image"}}
     src="/img/banners/banner-energycat-start.png"
@@ -17,5 +14,4 @@
       htmlSafe=true
     }}</p>
   </div>
-
-</div>
+</ProjectTemplate>

--- a/app/templates/panels/energycat.hbs
+++ b/app/templates/panels/energycat.hbs
@@ -4,11 +4,11 @@
     src="/img/banners/banner-energycat-start.png"
   />
 
-  <div class="project-part t1">
+  <div class="project-part">
     <p>{{t "category.slot.energycat.about"}}</p>
   </div>
 
-  <div class="project-part t2">
+  <div class="project-part">
     <p>{{t "category.slot.energycat.link"
       energaware="https://www.energaware.eu/#"
       htmlSafe=true

--- a/app/templates/panels/formidable.hbs
+++ b/app/templates/panels/formidable.hbs
@@ -1,4 +1,2 @@
-<div class="project-template borderleft">
-  <h1>{{t "category.slot.formidable.label"}}</h1>
-  <p>{{t "category.slot.formidable.intro"}}</p>
-</div>
+<ProjectTemplate @projectId="formidable">
+</ProjectTemplate>

--- a/app/templates/panels/homeplay.hbs
+++ b/app/templates/panels/homeplay.hbs
@@ -1,11 +1,11 @@
-<ProjectTemplate @projectId="homeplay">
+<ProjectTemplate @projectId="homeplay" as |tkey|>
   <div class="project-part">
-    <p>{{t "category.slot.homeplay.apis"}}</p>
+    <p>{{t (concat tkey "apis")}}</p>
   </div>
   <div class="project-part">
-    <p>{{t "category.slot.homeplay.limitations"}}</p>
+    <p>{{t (concat tkey "limitations")}}</p>
   </div>
   <div class="project-part">
-    <p>{{t "category.slot.homeplay.context"}}</p>
+    <p>{{t (concat tkey "context")}}</p>
   </div>
 </ProjectTemplate>

--- a/app/templates/panels/homeplay.hbs
+++ b/app/templates/panels/homeplay.hbs
@@ -1,6 +1,4 @@
-<div class="project-template borderleft">
-  <h1>{{t "category.slot.homeplay.label"}}</h1>
-  <p>{{t "category.slot.homeplay.intro"}}</p>
+<ProjectTemplate @projectId="homeplay">
   <div class="project-part t1">
     <p>{{t "category.slot.homeplay.apis"}}</p>
   </div>
@@ -10,4 +8,4 @@
   <div class="project-part t1">
     <p>{{t "category.slot.homeplay.context"}}</p>
   </div>
-</div>
+</ProjectTemplate>

--- a/app/templates/panels/homeplay.hbs
+++ b/app/templates/panels/homeplay.hbs
@@ -1,11 +1,11 @@
 <ProjectTemplate @projectId="homeplay">
-  <div class="project-part t1">
+  <div class="project-part">
     <p>{{t "category.slot.homeplay.apis"}}</p>
   </div>
-  <div class="project-part t2">
+  <div class="project-part">
     <p>{{t "category.slot.homeplay.limitations"}}</p>
   </div>
-  <div class="project-part t1">
+  <div class="project-part">
     <p>{{t "category.slot.homeplay.context"}}</p>
   </div>
 </ProjectTemplate>

--- a/app/templates/panels/imagana.hbs
+++ b/app/templates/panels/imagana.hbs
@@ -1,7 +1,4 @@
-<div class="project-template borderleft">
-  <h1>{{t "category.slot.imagana.label"}}</h1>
-  <p>{{t "category.slot.imagana.intro"}}</p>
-
+<ProjectTemplate @projectId="imagana">
   <div class="project-part t2">
     <h2><h2>{{t "general.trailer"}}</h2></h2>
     <div class="video">
@@ -57,5 +54,4 @@
     <h2>{{t "general.anecdote"}}</h2>
     <p>{{t "category.slot.imagana.anecdote"}}</p>
   </div>
-
-</div>
+</ProjectTemplate>

--- a/app/templates/panels/imagana.hbs
+++ b/app/templates/panels/imagana.hbs
@@ -1,9 +1,9 @@
-<ProjectTemplate @projectId="imagana">
+<ProjectTemplate @projectId="imagana" as |tkey|>
   <div class="project-part">
     <h2><h2>{{t "general.trailer"}}</h2></h2>
     <div class="video">
       <iframe
-        title={{t "category.slot.imagana.trailer"}}
+        title={{t (concat tkey "trailer")}}
         width="640"
         height="360"
         src="https://www.youtube.com/embed/JGfgdKd0yrU"
@@ -15,14 +15,14 @@
 
   <div class="project-part">
     <h2>{{t "general.about"}}</h2>
-    <p>{{t "category.slot.imagana.about1"}}</p>
-    <p>{{t "category.slot.imagana.about2"}}</p>
+    <p>{{t (concat tkey "about1")}}</p>
+    <p>{{t (concat tkey "about2")}}</p>
   </div>
 
   <div class="project-part">
     <h2>{{t "general.links"}}</h2>
-    <p>{{t "category.slot.imagana.links1"}}</p>
-    <p>{{t "category.slot.imagana.links2"
+    <p>{{t (concat tkey "links1")}}</p>
+    <p>{{t (concat tkey "links2")
       htmlSafe=true
       facebook="http://www.facebook.com/imaganalejeu"
     }}</p>
@@ -32,26 +32,26 @@
     <h2>{{t "general.gameplayVideo"}}</h2>
     <div class="video">
       <iframe
-        title={{t "category.slot.imagana.gameplay1"}}
+        title={{t (concat tkey "gameplay1")}}
         width="640"
         height="360"
         src="https://www.youtube.com/embed/yhXU5FAoBwU"
         frameborder="0" allowfullscreen>
       </iframe>
     </div>
-    <p>{{t "category.slot.imagana.gameplay2"
+    <p>{{t (concat tkey "gameplay2")
       htmlSafe=true
     }}</p>
   </div>
 
   <div class="project-part">
     <h2>{{t "general.universe"}}</h2>
-    <p>{{t "category.slot.imagana.universe1"}}</p>
-    <p>{{t "category.slot.imagana.universe2"}}</p>
+    <p>{{t (concat tkey "universe1")}}</p>
+    <p>{{t (concat tkey "universe2")}}</p>
   </div>
 
   <div class="project-part">
     <h2>{{t "general.anecdote"}}</h2>
-    <p>{{t "category.slot.imagana.anecdote"}}</p>
+    <p>{{t (concat tkey "anecdote")}}</p>
   </div>
 </ProjectTemplate>

--- a/app/templates/panels/imagana.hbs
+++ b/app/templates/panels/imagana.hbs
@@ -1,5 +1,5 @@
 <ProjectTemplate @projectId="imagana">
-  <div class="project-part t2">
+  <div class="project-part">
     <h2><h2>{{t "general.trailer"}}</h2></h2>
     <div class="video">
       <iframe
@@ -13,13 +13,13 @@
     </div>
   </div>
 
-  <div class="project-part t1">
+  <div class="project-part">
     <h2>{{t "general.about"}}</h2>
     <p>{{t "category.slot.imagana.about1"}}</p>
     <p>{{t "category.slot.imagana.about2"}}</p>
   </div>
 
-  <div class="project-part t2">
+  <div class="project-part">
     <h2>{{t "general.links"}}</h2>
     <p>{{t "category.slot.imagana.links1"}}</p>
     <p>{{t "category.slot.imagana.links2"
@@ -28,7 +28,7 @@
     }}</p>
   </div>
 
-  <div class="project-part t1">
+  <div class="project-part">
     <h2>{{t "general.gameplayVideo"}}</h2>
     <div class="video">
       <iframe
@@ -44,13 +44,13 @@
     }}</p>
   </div>
 
-  <div class="project-part t2">
+  <div class="project-part">
     <h2>{{t "general.universe"}}</h2>
     <p>{{t "category.slot.imagana.universe1"}}</p>
     <p>{{t "category.slot.imagana.universe2"}}</p>
   </div>
 
-  <div class="project-part t1">
+  <div class="project-part">
     <h2>{{t "general.anecdote"}}</h2>
     <p>{{t "category.slot.imagana.anecdote"}}</p>
   </div>

--- a/app/templates/panels/lepetitspirou.hbs
+++ b/app/templates/panels/lepetitspirou.hbs
@@ -1,5 +1,5 @@
 <ProjectTemplate @projectId="lepetitspirou">
-  <div class="project-part t2">
+  <div class="project-part">
     <h2>{{t "general.about"}}</h2>
     <p>{{t "category.slot.lepetitspirou.about1"}}</p>
     <p>{{t "category.slot.lepetitspirou.about2"}}</p>

--- a/app/templates/panels/lepetitspirou.hbs
+++ b/app/templates/panels/lepetitspirou.hbs
@@ -1,7 +1,7 @@
-<ProjectTemplate @projectId="lepetitspirou">
+<ProjectTemplate @projectId="lepetitspirou" as |tkey|>
   <div class="project-part">
     <h2>{{t "general.about"}}</h2>
-    <p>{{t "category.slot.lepetitspirou.about1"}}</p>
-    <p>{{t "category.slot.lepetitspirou.about2"}}</p>
+    <p>{{t (concat tkey "about1")}}</p>
+    <p>{{t (concat tkey "about2")}}</p>
   </div>
 </ProjectTemplate>

--- a/app/templates/panels/lepetitspirou.hbs
+++ b/app/templates/panels/lepetitspirou.hbs
@@ -1,11 +1,7 @@
-<div class="project-template borderleft">
-  <h1>{{t "category.slot.lepetitspirou.label"}}</h1>
-  <p>{{t "category.slot.lepetitspirou.intro"}}</p>
-
+<ProjectTemplate @projectId="lepetitspirou">
   <div class="project-part t2">
     <h2>{{t "general.about"}}</h2>
     <p>{{t "category.slot.lepetitspirou.about1"}}</p>
     <p>{{t "category.slot.lepetitspirou.about2"}}</p>
   </div>
-
-</div>
+</ProjectTemplate>

--- a/app/templates/panels/linkygame.hbs
+++ b/app/templates/panels/linkygame.hbs
@@ -1,6 +1,6 @@
-<ProjectTemplate @projectId="linkygame">
+<ProjectTemplate @projectId="linkygame" as |tkey|>
   <div class="project-part">
     <h2>{{t "general.about"}}</h2>
-    <p>{{t "category.slot.linkygame.about"}}</p>
+    <p>{{t (concat tkey "about")}}</p>
   </div>
 </ProjectTemplate>

--- a/app/templates/panels/linkygame.hbs
+++ b/app/templates/panels/linkygame.hbs
@@ -1,5 +1,5 @@
 <ProjectTemplate @projectId="linkygame">
-  <div class="project-part t2">
+  <div class="project-part">
     <h2>{{t "general.about"}}</h2>
     <p>{{t "category.slot.linkygame.about"}}</p>
   </div>

--- a/app/templates/panels/linkygame.hbs
+++ b/app/templates/panels/linkygame.hbs
@@ -1,10 +1,6 @@
-<div class="project-template borderleft">
-  <h1>{{t "category.slot.linkygame.label"}}</h1>
-  <p>{{t "category.slot.linkygame.intro"}}</p>
-
+<ProjectTemplate @projectId="linkygame">
   <div class="project-part t2">
     <h2>{{t "general.about"}}</h2>
     <p>{{t "category.slot.linkygame.about"}}</p>
   </div>
-
-</div>
+</ProjectTemplate>

--- a/app/templates/panels/mypeopledoc.hbs
+++ b/app/templates/panels/mypeopledoc.hbs
@@ -1,13 +1,13 @@
-<ProjectTemplate @projectId="mypeopledoc">
+<ProjectTemplate @projectId="mypeopledoc" as |tkey|>
   <div class="project-part">
-    <p>{{t "category.slot.mypeopledoc.about"}}</p>
+    <p>{{t (concat tkey "about")}}</p>
   </div>
   <div class="project-part">
-    <h2>{{t "category.slot.mypeopledoc.title1"}}</h2>
-    <p>{{t "category.slot.mypeopledoc.content1"}}</p>
+    <h2>{{t (concat tkey "title1")}}</h2>
+    <p>{{t (concat tkey "content1")}}</p>
   </div>
   <div class="project-part">
-    <h2>{{t "category.slot.mypeopledoc.title2"}}</h2>
-    <p>{{t "category.slot.mypeopledoc.content2"}}</p>
+    <h2>{{t (concat tkey "title2")}}</h2>
+    <p>{{t (concat tkey "content2")}}</p>
   </div>
 </ProjectTemplate>

--- a/app/templates/panels/mypeopledoc.hbs
+++ b/app/templates/panels/mypeopledoc.hbs
@@ -1,6 +1,4 @@
-<div class="project-template borderleft">
-  <h1>{{t "category.slot.mypeopledoc.label"}}</h1>
-  <p>{{t "category.slot.mypeopledoc.intro"}}</p>
+<ProjectTemplate @projectId="mypeopledoc">
   <div class="project-part t1">
     <p>{{t "category.slot.mypeopledoc.about"}}</p>
   </div>
@@ -12,4 +10,4 @@
     <h2>{{t "category.slot.mypeopledoc.title2"}}</h2>
     <p>{{t "category.slot.mypeopledoc.content2"}}</p>
   </div>
-</div>
+</ProjectTemplate>

--- a/app/templates/panels/mypeopledoc.hbs
+++ b/app/templates/panels/mypeopledoc.hbs
@@ -1,12 +1,12 @@
 <ProjectTemplate @projectId="mypeopledoc">
-  <div class="project-part t1">
+  <div class="project-part">
     <p>{{t "category.slot.mypeopledoc.about"}}</p>
   </div>
-  <div class="project-part t2">
+  <div class="project-part">
     <h2>{{t "category.slot.mypeopledoc.title1"}}</h2>
     <p>{{t "category.slot.mypeopledoc.content1"}}</p>
   </div>
-  <div class="project-part t1">
+  <div class="project-part">
     <h2>{{t "category.slot.mypeopledoc.title2"}}</h2>
     <p>{{t "category.slot.mypeopledoc.content2"}}</p>
   </div>

--- a/app/templates/panels/reef.hbs
+++ b/app/templates/panels/reef.hbs
@@ -1,7 +1,4 @@
-<div class="project-template borderleft">
-  <h1>{{t "category.slot.reef.label"}}</h1>
-  <p>{{t "category.slot.reef.intro"}}</p>
-
+<ProjectTemplate @projectId="reef">
   <div class="project-part t2">
     <h2>{{t "general.about"}}</h2>
     <p>{{t "category.slot.reef.content1"}}</p>
@@ -17,5 +14,4 @@
     <h2>{{t "general.anecdote"}}</h2>
     <p>{{t "category.slot.reef.content3"}}</p>
   </div>
-
-</div>
+</ProjectTemplate>

--- a/app/templates/panels/reef.hbs
+++ b/app/templates/panels/reef.hbs
@@ -1,8 +1,8 @@
-<ProjectTemplate @projectId="reef">
+<ProjectTemplate @projectId="reef" as |tkey|>
   <div class="project-part">
     <h2>{{t "general.about"}}</h2>
-    <p>{{t "category.slot.reef.content1"}}</p>
-    <p>{{t "category.slot.reef.content2"}}</p>
+    <p>{{t (concat tkey "content1")}}</p>
+    <p>{{t (concat tkey "content2")}}</p>
   </div>
 
   <div class="project-part">
@@ -12,6 +12,6 @@
 
   <div class="project-part">
     <h2>{{t "general.anecdote"}}</h2>
-    <p>{{t "category.slot.reef.content3"}}</p>
+    <p>{{t (concat tkey "content3")}}</p>
   </div>
 </ProjectTemplate>

--- a/app/templates/panels/reef.hbs
+++ b/app/templates/panels/reef.hbs
@@ -1,16 +1,16 @@
 <ProjectTemplate @projectId="reef">
-  <div class="project-part t2">
+  <div class="project-part">
     <h2>{{t "general.about"}}</h2>
     <p>{{t "category.slot.reef.content1"}}</p>
     <p>{{t "category.slot.reef.content2"}}</p>
   </div>
 
-  <div class="project-part t1">
+  <div class="project-part">
     <h2>{{t "general.trailer"}}</h2>
     <div class="video"><video controls src="/video/reef_gameplay.mp4" width="640" height="360"></video></div>
   </div>
 
-  <div class="project-part t2">
+  <div class="project-part">
     <h2>{{t "general.anecdote"}}</h2>
     <p>{{t "category.slot.reef.content3"}}</p>
   </div>

--- a/app/templates/panels/renard.hbs
+++ b/app/templates/panels/renard.hbs
@@ -1,6 +1,4 @@
-<div class="project-template borderleft">
-  <h1>{{t "category.slot.renard.label"}}</h1>
-  <p>{{t "category.slot.renard.intro"}}</p>
+<ProjectTemplate @projectId="renard">
   <a href="http://academie-des-renards.dunstetter.fr/"
     target="_blank"
     rel="noopener noreferrer"
@@ -23,4 +21,4 @@
       />
     </a>
   </div>
-</div>
+</ProjectTemplate>

--- a/app/templates/panels/renard.hbs
+++ b/app/templates/panels/renard.hbs
@@ -1,22 +1,22 @@
-<ProjectTemplate @projectId="renard">
+<ProjectTemplate @projectId="renard" as |tkey|>
   <a href="http://academie-des-renards.dunstetter.fr/"
     target="_blank"
     rel="noopener noreferrer"
   >
     <img class="shadowbox"
-      alt={{t "category.slot.renard.site"}}
+      alt={{t (concat tkey "site")}}
       src="/img/banners/banner-adr.png"
     />
   </a>
   <div class="project-part aligncenter">
-    <p>{{t "category.slot.renard.drawings"}}</p>
+    <p>{{t (concat tkey "drawings")}}</p>
     <a href="https://instagram.com/academiedesrenards/"
       target="_blank"
       rel="noopener noreferrer"
     >
-      {{t "category.slot.renard.checkInstragram"}} &#8594;
+      {{t (concat tkey "checkInstragram")}} &#8594;
       <img class="logo"
-        alt={{t "category.slot.renard.iconInstragram"}}
+        alt={{t (concat tkey "iconInstragram")}}
         src="/img/logos/instagram.png"
       />
     </a>

--- a/app/templates/panels/renard.hbs
+++ b/app/templates/panels/renard.hbs
@@ -8,7 +8,7 @@
       src="/img/banners/banner-adr.png"
     />
   </a>
-  <div class="project-part t1 aligncenter">
+  <div class="project-part aligncenter">
     <p>{{t "category.slot.renard.drawings"}}</p>
     <a href="https://instagram.com/academiedesrenards/"
       target="_blank"

--- a/app/templates/panels/srg.hbs
+++ b/app/templates/panels/srg.hbs
@@ -1,10 +1,6 @@
-<div class="project-template borderleft">
-  <h1>{{t "category.slot.srg.label"}}</h1>
-  <p>{{t "category.slot.srg.intro"}}</p>
-
+<ProjectTemplate @projectId="srg">
   <div class="project-part t2">
     <h2>{{t "general.about"}}</h2>
     <p>{{t "category.slot.srg.about"}}</p>
   </div>
-
-</div>
+</ProjectTemplate>

--- a/app/templates/panels/srg.hbs
+++ b/app/templates/panels/srg.hbs
@@ -1,6 +1,6 @@
-<ProjectTemplate @projectId="srg">
+<ProjectTemplate @projectId="srg" as |tkey|>
   <div class="project-part">
     <h2>{{t "general.about"}}</h2>
-    <p>{{t "category.slot.srg.about"}}</p>
+    <p>{{t (concat tkey "about")}}</p>
   </div>
 </ProjectTemplate>

--- a/app/templates/panels/srg.hbs
+++ b/app/templates/panels/srg.hbs
@@ -1,5 +1,5 @@
 <ProjectTemplate @projectId="srg">
-  <div class="project-part t2">
+  <div class="project-part">
     <h2>{{t "general.about"}}</h2>
     <p>{{t "category.slot.srg.about"}}</p>
   </div>

--- a/app/templates/panels/stupidhermitcrab.hbs
+++ b/app/templates/panels/stupidhermitcrab.hbs
@@ -1,10 +1,10 @@
 <ProjectTemplate @projectId="stupidhermitcrab">
-  <div class="project-part t2">
+  <div class="project-part">
     <h2>{{t "general.about"}}</h2>
     <p>{{t "category.slot.stupidhermitcrab.content2"}}</p>
   </div>
 
-  <div class="project-part t1">
+  <div class="project-part">
     <h2>{{t "general.executable"}}</h2>
     <p>{{t "category.slot.stupidhermitcrab.download"
       htmlSafe=true
@@ -12,13 +12,13 @@
     }}</p>
   </div>
 
-  <div class="project-part t2">
+  <div class="project-part">
     <h2>{{t "general.gameplayVideo"}}</h2>
     <p>{{t "category.slot.stupidhermitcrab.content1"}}</p>
     <div class="video"><video controls src="/video/shc_gameplay.avi" width="640" height="360"></video></div>
   </div>
 
-  <div class="project-part t1">
+  <div class="project-part">
     <h2>{{t "general.anecdote"}}</h2>
     <p>{{t "category.slot.stupidhermitcrab.content3"}}</p>
   </div>

--- a/app/templates/panels/stupidhermitcrab.hbs
+++ b/app/templates/panels/stupidhermitcrab.hbs
@@ -1,12 +1,12 @@
-<ProjectTemplate @projectId="stupidhermitcrab">
+<ProjectTemplate @projectId="stupidhermitcrab" as |tkey|>
   <div class="project-part">
     <h2>{{t "general.about"}}</h2>
-    <p>{{t "category.slot.stupidhermitcrab.content2"}}</p>
+    <p>{{t (concat tkey "content2")}}</p>
   </div>
 
   <div class="project-part">
     <h2>{{t "general.executable"}}</h2>
-    <p>{{t "category.slot.stupidhermitcrab.download"
+    <p>{{t (concat tkey "download")
       htmlSafe=true
       mediafire="http://www.mediafire.com/download/axtnkaynw9vmoh6/Stupid+Hermit+Crab.zip"
     }}</p>
@@ -14,12 +14,12 @@
 
   <div class="project-part">
     <h2>{{t "general.gameplayVideo"}}</h2>
-    <p>{{t "category.slot.stupidhermitcrab.content1"}}</p>
+    <p>{{t (concat tkey "content1")}}</p>
     <div class="video"><video controls src="/video/shc_gameplay.avi" width="640" height="360"></video></div>
   </div>
 
   <div class="project-part">
     <h2>{{t "general.anecdote"}}</h2>
-    <p>{{t "category.slot.stupidhermitcrab.content3"}}</p>
+    <p>{{t (concat tkey "content3")}}</p>
   </div>
 </ProjectTemplate>

--- a/app/templates/panels/stupidhermitcrab.hbs
+++ b/app/templates/panels/stupidhermitcrab.hbs
@@ -1,7 +1,4 @@
-<div class="project-template borderleft">
-  <h1>{{t "category.slot.stupidhermitcrab.label"}}</h1>
-  <p>{{t "category.slot.stupidhermitcrab.intro"}}</p>
-
+<ProjectTemplate @projectId="stupidhermitcrab">
   <div class="project-part t2">
     <h2>{{t "general.about"}}</h2>
     <p>{{t "category.slot.stupidhermitcrab.content2"}}</p>
@@ -25,5 +22,4 @@
     <h2>{{t "general.anecdote"}}</h2>
     <p>{{t "category.slot.stupidhermitcrab.content3"}}</p>
   </div>
-
-</div>
+</ProjectTemplate>

--- a/app/templates/panels/superkoala.hbs
+++ b/app/templates/panels/superkoala.hbs
@@ -1,10 +1,6 @@
-<div class="project-template borderleft">
-  <h1>{{t "category.slot.superkoala.label"}}</h1>
-  <p>{{t "category.slot.superkoala.intro"}}</p>
-
+<ProjectTemplate @projectId="superkoala">
   <div class="project-part t2">
     <h2>{{t "general.about"}}</h2>
     <p>{{t "category.slot.superkoala.content1"}}</p>
   </div>
-
-</div>
+</ProjectTemplate>

--- a/app/templates/panels/superkoala.hbs
+++ b/app/templates/panels/superkoala.hbs
@@ -1,5 +1,5 @@
 <ProjectTemplate @projectId="superkoala">
-  <div class="project-part t2">
+  <div class="project-part">
     <h2>{{t "general.about"}}</h2>
     <p>{{t "category.slot.superkoala.content1"}}</p>
   </div>

--- a/app/templates/panels/superkoala.hbs
+++ b/app/templates/panels/superkoala.hbs
@@ -1,6 +1,6 @@
-<ProjectTemplate @projectId="superkoala">
+<ProjectTemplate @projectId="superkoala" as |tkey|>
   <div class="project-part">
     <h2>{{t "general.about"}}</h2>
-    <p>{{t "category.slot.superkoala.content1"}}</p>
+    <p>{{t (concat tkey "content1")}}</p>
   </div>
 </ProjectTemplate>

--- a/app/templates/panels/travel.hbs
+++ b/app/templates/panels/travel.hbs
@@ -1,12 +1,12 @@
-<ProjectTemplate @projectId="travel">
+<ProjectTemplate @projectId="travel" as |tkey|>
   <div class="project-part">
-    <p>{{t "category.slot.travel.japanIntro"}}</p>
+    <p>{{t (concat tkey "japanIntro")}}</p>
     <a href="https://panodyssey.com/fr/creative/room/les-carnets-du-japon-e65ncc9kc74q"
       target="_blank"
       rel="noopener noreferrer"
     >
       <img class="shadowbox"
-        alt={{t "category.slot.travel.japanNotes"}}
+        alt={{t (concat tkey "japanNotes")}}
         src="/img/banners/banner-himeji.JPG"
       />
     </a>

--- a/app/templates/panels/travel.hbs
+++ b/app/templates/panels/travel.hbs
@@ -1,6 +1,4 @@
-<div class="project-template borderleft">
-  <h1>{{t "category.slot.travel.label"}}</h1>
-  <p>{{t "category.slot.travel.intro"}}</p>
+<ProjectTemplate @projectId="travel">
   <div class="project-part t1">
     <p>{{t "category.slot.travel.japanIntro"}}</p>
     <a href="https://panodyssey.com/fr/creative/room/les-carnets-du-japon-e65ncc9kc74q"
@@ -13,4 +11,4 @@
       />
     </a>
   </div>
-</div>
+</ProjectTemplate>

--- a/app/templates/panels/travel.hbs
+++ b/app/templates/panels/travel.hbs
@@ -1,5 +1,5 @@
 <ProjectTemplate @projectId="travel">
-  <div class="project-part t1">
+  <div class="project-part">
     <p>{{t "category.slot.travel.japanIntro"}}</p>
     <a href="https://panodyssey.com/fr/creative/room/les-carnets-du-japon-e65ncc9kc74q"
       target="_blank"

--- a/tests/integration/components/project-template-test.js
+++ b/tests/integration/components/project-template-test.js
@@ -1,0 +1,26 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Component | project-template', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders the title and intro for the given @projectId', async function (assert) {
+    await render(hbs`<ProjectTemplate @projectId="reef" />`);
+    assert.dom('h1').hasText('Reef');
+    assert
+      .dom('p')
+      .exists({ count: 1 })
+      .includesText('A relaxing serious game inspired by Biorock technology.');
+
+    await render(hbs`
+      <ProjectTemplate @projectId="reef">
+        <p class="desc">Project custom description.</p>
+      </ProjectTemplate>
+    `);
+    assert.dom('h1').hasText('Reef');
+    assert.dom('p').exists({ count: 2 });
+    assert.dom('.desc').hasText('Project custom description.');
+  });
+});

--- a/tests/integration/components/project-template-test.js
+++ b/tests/integration/components/project-template-test.js
@@ -23,4 +23,13 @@ module('Integration | Component | project-template', function (hooks) {
     assert.dom('p').exists({ count: 2 });
     assert.dom('.desc').hasText('Project custom description.');
   });
+
+  test('it provides a positional param for translation key', async function (assert) {
+    await render(hbs`
+      <ProjectTemplate @projectId="reef" as |tkey|>
+        <p class="key">{{tkey}}</p>
+      </ProjectTemplate>
+    `);
+    assert.dom('.key').hasText('category.slot.reef.');
+  });
 });


### PR DESCRIPTION
## Refactor
### Factorize project template header
A `<ProjectTemplate>` component has been introduced to make sure the title an introduction of a project have shared structure across all project templates. 
This component builds the translation prefix for the given project id and provide it to the block to avoid errors in the repeating key.

```hbs
<ProjectTemplate @projectId="greatproject" as |tkey|>
   {{!-- Show translation for "category.slot.greatproject.about" --}}
   <p>{{t (concat tkey "about")}}</p>
</ProjectTemplate>
```

### Alternate blocks color with `nth-child(odd)`
The previous CSS classes `.t1` and `.t2` have been removed in favor of a `nth-child(odd)` CSS rule that alternates blocks color in project templates.
