### PR TITLE
Refactor/ Define explicit rest serializer for application

### DIFF
--- a/app/models/me.js
+++ b/app/models/me.js
@@ -2,7 +2,6 @@ import Model, { attr } from '@ember-data/model';
 
 export default class MeModel extends Model {
   @attr('string') name;
-  @attr('string') title;
   @attr('string') mail;
   @attr networks;
 }

--- a/app/serializers/application.js
+++ b/app/serializers/application.js
@@ -1,0 +1,3 @@
+import RESTSerializer from '@ember-data/serializer/rest';
+
+export default class ApplicationSerializer extends RESTSerializer {}

--- a/tests/unit/serializers/application-test.js
+++ b/tests/unit/serializers/application-test.js
@@ -1,0 +1,35 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Serializer | application', function (hooks) {
+  setupTest(hooks);
+
+  test('it serializes me records', function (assert) {
+    let store = this.owner.lookup('service:store');
+    let record = store.createRecord('me', {
+      id: 1,
+      name: 'Marine Dunstetter',
+      mail: 'mdunstetter@gmail.com',
+      networks: [
+        {
+          id: 'github',
+          link: 'https://github.com/BlueCutOfficial',
+          logo: '/img/logos/github.png',
+        },
+      ],
+    });
+
+    let serializedRecord = record.serialize();
+    assert.deepEqual(serializedRecord, {
+      name: 'Marine Dunstetter',
+      mail: 'mdunstetter@gmail.com',
+      networks: [
+        {
+          id: 'github',
+          link: 'https://github.com/BlueCutOfficial',
+          logo: '/img/logos/github.png',
+        },
+      ],
+    });
+  });
+});


### PR DESCRIPTION
## Refactor
### Define explicit REST serializer for application
No application serializer was explicitly defined. `ember-data` was able to guess the serializer REST must be used using the adapter type, but this behavior is deprecated. The REST serializer is now explicitly imported for the application.

### Remove `title` prop from `Me` model
The title is now a translated string rather than a property of the `Me` model, as there is no reason to have several translation key for a translatable static title.